### PR TITLE
Fixes to allow gmime3, mu and xapian-core build and use DLL's in MSYS2.

### DIFF
--- a/gmime3/PKGBUILD
+++ b/gmime3/PKGBUILD
@@ -24,9 +24,9 @@ sha256sums=('2aea96647a468ba2160a64e17c6dc6afe674ed9ac86070624a3f584c10737d44')
 
 build() {
     cd "gmime-${pkgver}"
-
-    ./configure --prefix=/usr
-                # --disable-static
+    patch -p0 < ../../install.patch
+    autoreconf --install -f --verbose
+    ./configure --prefix=/usr --disable-static --enable-shared
     make
 }
 

--- a/gmime3/install.patch
+++ b/gmime3/install.patch
@@ -1,0 +1,11 @@
+--- configure.ac	2020-12-04 16:17:53.305836400 +0100
++++ ../../configure.ac	2020-12-04 16:18:01.969507400 +0100
+@@ -94,7 +94,7 @@
+ AC_MSG_CHECKING([if building for Win32])
+ LIB_EXE_MACHINE_FLAG=X86
+ case "$host" in
+-  *-*-mingw*)
++  *-*-mingw*|*-*-msys*)
+     platform_win32="yes"
+     native_win32="yes"
+     case "$host" in

--- a/mu/PKGBUILD
+++ b/mu/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mu
 # _date="`date +%Y-%m-%d@%H-%M-%S`"
 pkgname=${_realname}-git #-${_date}
-pkgver=20200815
+pkgver=20201202
 pkgrel=1
 pkgdesc="'mu' is a tool for dealing with e-mail messages stored in the Maildir-format."
 arch=('i686' 'x86_64')

--- a/xapian-core/PKGBUILD
+++ b/xapian-core/PKGBUILD
@@ -22,8 +22,8 @@ sha512sums=('f28209acae12a42a345382668f7f7da7a2ce5a08362d0e2af63c9f94cb2adca9536
 
 build() {
     cd ${pkgname}-${pkgver}
-    ./configure \
-        --prefix=/usr
+    autoreconf --install -f --verbose
+    ./configure --prefix=/usr --disable-dependency-tracking
     make
 }
 


### PR DESCRIPTION
I tried using the recipes in MSYS2-packages to build 'mu', using 'gmime3' and 'xapian-core', but it failed because the latter software was unable to build shared libraries. This was identified as due to (i) old versions of libtool *.m4 files and (ii) missing LDFLAGS -no-undefined in gmime3. This patch addresses those issues.