### PR TITLE
Create PKGBUILD

### DIFF
--- a/xapian-bindings/PKGBUILD
+++ b/xapian-bindings/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: helohe
+
+pkgname=xapian-bindings
+# epoch=1
+pkgver=1.4.18
+pkgrel=1
+pkgdesc='Open source search engine library, bindings.'
+arch=('i686' 'x86_64')
+url='https://www.xapian.org/'
+license=('GPL')
+depends=('libutil-linux-devel' 'zlib-devel')
+makedepends=(gcc gcc-libs make libtool autoconf automake)
+# xapian config requires libxapian.la
+options=('libtool')
+source=("https://oligarchy.co.uk/xapian/${pkgver}/${pkgname}-${pkgver}.tar.xz")
+#{,.asc})
+sha256sums=('FE52064E90D202F7819130AE3AD013C8B2B9CB517AD9FD607CF41D0110C5F18F')
+# validpgpkeys=('08E2400FF7FE8FEDE3ACB52818147B073BAD2B07') # Olly Betts <olly@debian.org>
+
+build() {
+    cd ${pkgname}-${pkgver}
+    autoreconf --install -f --verbose
+    ./configure --prefix=/usr --without-perl
+    make
+}
+
+package() {
+    cd ${pkgname}-${pkgver}
+    make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
the gem xapian-ruby does not seem to compile on msys2. So I created this package. This works. (perl bindings do not work and I am not sure which dependencies to list, should probably be xapian itself and the languages one wants to use. I only needed ruby for sup).