### PR TITLE
bump xapian-core, gmime3, mu

### DIFF
--- a/gmime3/PKGBUILD
+++ b/gmime3/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: damon-kwok <damon-kwok@outlook.com>
 
 pkgname=gmime3
-pkgver=3.2.7
+pkgver=3.2.15
 pkgrel=1
 pkgdesc="The GMime package contains a set of utilities for parsing and creating messages using the Multipurpose Internet Mail Extension (MIME) as defined by the applicable RFCs."
 arch=('i686' 'x86_64')
@@ -11,8 +11,8 @@ url="https://github.com/jstedfast/gmime"
 depends=(glib2-devel libiconv-devel zlib-devel libgpg-error-devel)
 makedepends=(gcc gcc-libs make libtool autoconf automake pkg-config gtk-doc)
 provides=(libgmime-3.0.so)
-source=(http://ftp.gnome.org/pub/gnome/sources/gmime/3.2/gmime-${pkgver}.tar.xz)
-sha256sums=('2aea96647a468ba2160a64e17c6dc6afe674ed9ac86070624a3f584c10737d44')
+source=(https://github.com/jstedfast/gmime/releases/download/${pkgver}/gmime-${pkgver}.tar.xz)
+sha256sums=('84cd2a481a27970ec39b5c95f72db026722904a2ccf3fdbd57b280cf2d02b5c4')
 
 # depends=(glib2 gpgme zlib libidn2)
 # makedepends=(gobject-introspection gtk-doc git vala docbook-utils)
@@ -26,7 +26,7 @@ build() {
     cd "gmime-${pkgver}"
     patch -p0 < ../../install.patch
     autoreconf --install -f --verbose
-    ./configure --prefix=/usr --disable-static --enable-shared
+    ./configure --prefix=/usr  --enable-static --disable-shared
     make
 }
 

--- a/mu/PKGBUILD
+++ b/mu/PKGBUILD
@@ -1,9 +1,7 @@
 # Maintainer: damon-kwok <damon-kwok@outlook.com>
 
-_realname=mu
-# _date="`date +%Y-%m-%d@%H-%M-%S`"
-pkgname=${_realname}-git #-${_date}
-pkgver=20221009
+pkgname=mu
+pkgver=1.14.0
 pkgrel=1
 pkgdesc="'mu' is a tool for dealing with e-mail messages stored in the Maildir-format."
 arch=('i686' 'x86_64')
@@ -15,21 +13,18 @@ url="https://www.djcbsoftware.nl/code/mu/"
 depends=(xapian-core libiconv diffutils)
 makedepends=(cmake meson pkg-config autogen autotools git emacs glib2-devel libiconv-devel xapian-core gmime3 libreadline-devel)
 options=(guile)
-source=("git+https://github.com/damon-kwok/mu")
-sha256sums=('SKIP')
-
-pkgver() {
-  cd "${srcdir}"/${_realname}
-  # printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
-  git log -1 --format="%cd" --date=short | sed 's|-||g'
-}
+source=(https://github.com/djcb/mu/releases/download/v${pkgver}/mu-${pkgver}.tar.xz)
+sha256sums=('c5d338ee81664c29d18de757017942b14d01fe313d6fea82f8b7c66c6fd4354a')
 
 build() {
-    cd "${srcdir}"/${_realname}
+    cd "mu-${pkgver}"
     sed -i 's/c++17/gnu++17/g' meson.build
     sed -i 's/-Wno-#warnings/-D_GNU_SOURCE/g' meson.build
     chmod +x ./autogen.sh
     ./autogen.sh
+    sed -i 's/-std=c++20/-std=c++20 -include unistd.h -include stdlib.h -include cstdio -include signal.h -include wchar.h/g' build/build.ninja
+    sed -i 's/-ladvapi32 -Wl,--end-group/-ladvapi32 -liconv -lz -Wl,--end-group/g' build/build.ninja
+    sed -i 's/-std=c++20/-std=c++20 -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -include unistd.h -include stdlib.h -include cstdio -include signal.h -include wchar.h/g' build/build.ninja
     make
 }
 

--- a/mu/PKGBUILD-git
+++ b/mu/PKGBUILD-git
@@ -23,8 +23,13 @@ pkgver() {
 
 build() {
     cd "${srcdir}"/${_realname}
+    sed -i 's/c++17/gnu++17/g' meson.build
+    sed -i 's/-Wno-#warnings/-D_GNU_SOURCE/g' meson.build
     chmod +x ./autogen.sh
     ./autogen.sh
+    sed -i 's/-std=c++20/-std=c++20 -include unistd.h -include stdlib.h -include cstdio -include signal.h -include wchar.h/g' build/build.ninja
+    sed -i 's/-ladvapi32 -Wl,--end-group/-ladvapi32 -liconv -lz -Wl,--end-group/g' build/build.ninja
+    sed -i 's/-std=c++20/-std=c++20 -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -include unistd.h -include stdlib.h -include cstdio -include signal.h -include wchar.h/g' build/build.ninja
     make
 }
 

--- a/xapian-core/PKGBUILD
+++ b/xapian-core/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=xapian-core
 # epoch=1
-pkgver=1.4.21
+pkgver=1.4.26
 pkgrel=1
 pkgdesc='Open source search engine library.'
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ makedepends=(gcc gcc-libs make libtool autoconf automake)
 options=('libtool')
 source=("https://oligarchy.co.uk/xapian/${pkgver}/${pkgname}-${pkgver}.tar.xz")
 #{,.asc})
-sha256sums=('80f86034d2fb55900795481dfae681bfaa10efbe818abad3622cdc0c55e06f88')
+sha256sums=('9e6a7903806966d16ce220b49377c9c8fad667c8f0ffcb23a3442946269363a7')
 # validpgpkeys=('08E2400FF7FE8FEDE3ACB52818147B073BAD2B07') # Olly Betts <olly@debian.org>
 
 build() {


### PR DESCRIPTION
Hi, 

upstream mu builds fine now, no need to maintain your own fork. 
mu 1.14.0 needs newer xapian-core and gmime3, thats why I updated them.

I usually package for gentoo, so take this PR with a grain of salt and check it thoroughly. I don't know what it idiomatic for pacman / MSYS2. 

